### PR TITLE
Move refun step

### DIFF
--- a/source/public/journey-7/0-start.slim
+++ b/source/public/journey-7/0-start.slim
@@ -56,7 +56,7 @@ form
 
   .row
     .small-12.columns
-      a href='status.html'
+      a href='refund.html'
         .button.success.large Apply now
   br
   .row

--- a/source/public/journey-7/address.slim
+++ b/source/public/journey-7/address.slim
@@ -26,7 +26,7 @@ form
   br
   .row
     .small-12.columns
-      a href='contact.html'
+      a#next-url href='contact.html'
         .button.success Continue
 
 
@@ -34,6 +34,9 @@ form
 
 javascript:
   $(document).ready( function() {
+    buildNextUrl('contact.html');
+    $('#refund-true').toggle(getUrlParameter('refund') == 'true');
+    $('#refund-false').toggle(getUrlParameter('refund') == 'false');
   });
 
   $("input[name='case']").on('change', function () {

--- a/source/public/journey-7/benefits.slim
+++ b/source/public/journey-7/benefits.slim
@@ -11,7 +11,8 @@ form
       span.hint &nbsp; &nbsp; Step 4 of 17
       br
       br
-      h4 Do you receive any of the following benefits?
+      h4#refund-true Do you receive any of the following benefits?
+      h4#refund-false I've no idea what this should say!
       p We’ll contact the Department for Work and Pensions to confirm that you are (or were) getting one of these benefits.
   .row      
     .small-12.medium-6.columns
@@ -97,6 +98,8 @@ form
 
 javascript:
   $(document).ready( function() {
+    $('#refund-true').toggle(getUrlParameter('refund') == 'true');
+    $('#refund-false').toggle(getUrlParameter('refund') == 'false');
   });
 
   $("input[name='payment-correct']").on('change', function () {

--- a/source/public/journey-7/benefits.slim
+++ b/source/public/journey-7/benefits.slim
@@ -4,57 +4,106 @@ nav_title: 'GOV.UK'
 ---
 
 form
-  .row
-    .small-12.medium-7.columns
-      br
-      a href="savings.html" Back
-      span.hint &nbsp; &nbsp; Step 4 of 17
-      br
-      br
-      h4#refund-true Do you receive any of the following benefits?
-      h4#refund-false I've no idea what this should say!
-      p We’ll contact the Department for Work and Pensions to confirm that you are (or were) getting one of these benefits.
-  .row      
-    .small-12.medium-6.columns
-      ul
-        li 
-          span Income-based Jobseeker’s Allowance
-          span.hint
-            |&nbsp;(JSA)
-        li 
-          span Income-related Employment and Support Allowance
-          span.hint
-            |&nbsp;(ESA)
-        li 
-          span Income Support
-        li 
-          span Universal Credit 
-          span.hint
-            |&nbsp;(and you’re earning less than £6,000 a year)
-        li 
-          span State Pension
-          span.hint
-            |&nbsp;(Guarantee Credit)
-        li
-          span Scottish Civil Legal Aid 
-          span.hint
-            |&nbsp;(not Advice and Assistance or Advice by Way of Representation)
-  
+  #refund-false
+    .row
+      .small-12.medium-7.columns
+        br
+        a href="savings.html" Back
+        span.hint &nbsp; &nbsp; Step 7 of 18
+        br
+        br
+        h4 Do you receive any of the following benefits?
+        p We’ll contact the Department for Work and Pensions to confirm that you are (or were) getting one of these benefits.
+    
+    .row      
+      .small-12.medium-6.columns
+        ul
+          li 
+            span Income-based Jobseeker’s Allowance
+            span.hint
+              |&nbsp;(JSA)
+          li 
+            span Income-related Employment and Support Allowance
+            span.hint
+              |&nbsp;(ESA)
+          li 
+            span Income Support
+          li 
+            span Universal Credit 
+            span.hint
+              |&nbsp;(and you’re earning less than £6,000 a year)
+          li 
+            span State Pension
+            span.hint
+              |&nbsp;(Guarantee Credit)
+          li
+            span Scottish Civil Legal Aid 
+            span.hint
+              |&nbsp;(not Advice and Assistance or Advice by Way of Representation)
+    
+    br
+    .row
+      .small-12.medium-6.columns   
+        .options.radio
+          .option
+            label for="payment-correct-no-false"
+              input id="payment-correct-no-false" type="radio" name="payment-correct" value="false"
+              | No
+          .option
+            label for="payment-correct-yes-false"
+              input id="payment-correct-yes-false" type="radio" name="payment-correct" value="true"
+              | Yes, I am receiving one of the benefits listed
 
+  #refund-true
+    .row
+      .small-12.medium-7.columns
+        br
+        a href="savings.html" Back
+        span.hint &nbsp; &nbsp; Step 7 of 18
+        br
+        br
+        h4 When you paid the fee, did you receive any of the following benefits?
+        p We’ll contact the Department for Work and Pensions to confirm that you are (or were) getting one of these benefits.
+    
+    .row      
+      .small-12.medium-6.columns
+        ul
+          li 
+            span Income-based Jobseeker’s Allowance
+            span.hint
+              |&nbsp;(JSA)
+          li 
+            span Income-related Employment and Support Allowance
+            span.hint
+              |&nbsp;(ESA)
+          li 
+            span Income Support
+          li 
+            span Universal Credit 
+            span.hint
+              |&nbsp;(and you’re earning less than £6,000 a year)
+          li 
+            span State Pension
+            span.hint
+              |&nbsp;(Guarantee Credit)
+          li
+            span Scottish Civil Legal Aid 
+            span.hint
+              |&nbsp;(not Advice and Assistance or Advice by Way of Representation)
+    
+    br
+    .row
+      .small-12.medium-6.columns   
+        .options.radio
+          .option
+            label for="payment-correct-no-true"
+              input id="payment-correct-no-true" type="radio" name="payment-correct" value="false"
+              | No
+          .option
+            label for="payment-correct-yes-true"
+              input id="payment-correct-yes-true" type="radio" name="payment-correct" value="true"
+              | Yes, I was receiving one of the benefits listed
 
-
-  br
-  .row
-    .small-12.medium-6.columns   
-      .options.radio
-        .option
-          label for="payment-correct-no"
-            input id="payment-correct-no" type="radio" name="payment-correct" value="false"
-            | No
-        .option
-          label for="payment-correct-yes"
-            input id="payment-correct-yes" type="radio" name="payment-correct" value="true"
-            | Yes, I am receiving one of the benefits listed
 
   br
   .row
@@ -92,17 +141,18 @@ form
   br
   .row
     .small-12.medium-12.large-12.columns
-      a#next-url href='refund.html'
+      a#next-url href='probate.html'
         .button.success Continue
 
 
 javascript:
   $(document).ready( function() {
+    buildNextUrl('probate.html');
     $('#refund-true').toggle(getUrlParameter('refund') == 'true');
     $('#refund-false').toggle(getUrlParameter('refund') == 'false');
   });
 
   $("input[name='payment-correct']").on('change', function () {
     $('#payment-comment').toggleClass('hide', $("input[name='payment-correct']:checked").val() == "true");
-    buildNextUrl($("input[name='payment-correct']:checked").val() == "true" ? 'refund.html' : 'children.html');
+    //buildNextUrl($("input[name='payment-correct']:checked").val() == "true" ? 'probate.html' : 'children.html');
   });

--- a/source/public/journey-7/case-number.slim
+++ b/source/public/journey-7/case-number.slim
@@ -45,7 +45,7 @@ form
   br
   .row
     .small-12.columns
-      a href='form-number.html'
+      a#next-url href='form-number.html'
         .button.success Continue
 
 
@@ -53,9 +53,12 @@ form
 
 javascript:
   $(document).ready( function() {
+    buildNextUrl('form-number.html');
+    $('#refund-true').toggle(getUrlParameter('refund') == 'true');
+    $('#refund-false').toggle(getUrlParameter('refund') == 'false');
   });
 
   $("input[name='case']").on('change', function () {
     $('#case-number').toggleClass('hide', $("input[name='case']:checked").val() == "true");
-    buildNextUrl($("input[name='case']:checked").val() == "true" ? '#.html' : '#.html');
+    //buildNextUrl($("input[name='case']:checked").val() == "true" ? '#.html' : '#.html');
   });

--- a/source/public/journey-7/children.slim
+++ b/source/public/journey-7/children.slim
@@ -8,7 +8,7 @@ form
     .small-12.medium-6.columns
       br
       a href="benefits.html" Back
-      span.hint &nbsp; &nbsp; Step 5 of 17
+      span.hint &nbsp; &nbsp; Step 8 of 18
       br
       br
       h4 Do you have any children living with you, or who you support financially?
@@ -36,7 +36,7 @@ form
   br
   .row
     .small-12.columns
-      a href='income-single.html'
+      a#next-url href='income-single.html'
         .button.success Continue
 
 
@@ -44,6 +44,9 @@ form
 
 javascript:
   $(document).ready( function() {
+    buildNextUrl('income-single.html');
+    $('#refund-true').toggle(getUrlParameter('refund') == 'true');
+    $('#refund-false').toggle(getUrlParameter('refund') == 'false');
   });
 
   $("input[name='kid']").on('change', function () {

--- a/source/public/journey-7/contact.slim
+++ b/source/public/journey-7/contact.slim
@@ -35,13 +35,14 @@ form
             input id="email" name="email" type="checkbox" Check this box if you're willing to share your experience of this service. A member of the team may contact you. We won't use your email address for anything else. 
  
       br
-      a href="summary.html" 
+      a#next-url href="summary.html" 
         .button.success Continue
 
 
 javascript:
+
   $(document).ready( function() {
-    buildNextUrl('3-savings.html');
+    buildNextUrl('summary.html');
     $('#fee').bind('change', function () {
       $("#next-url").attr("href", updateQueryStringParameter('fee', $(this).val()));
     });

--- a/source/public/journey-7/dob.slim
+++ b/source/public/journey-7/dob.slim
@@ -34,7 +34,7 @@ form
   br
   .row
     .small-12.columns
-      a href='name.html'
+      a#next-url href='name.html'
         .button.success Continue
 
 
@@ -42,9 +42,12 @@ form
 
 javascript:
   $(document).ready( function() {
+    buildNextUrl('name.html');
+    $('#refund-true').toggle(getUrlParameter('refund') == 'true');
+    $('#refund-false').toggle(getUrlParameter('refund') == 'false');
   });
 
   $("input[name='refund']").on('change', function () {
     $('#refund-details').toggleClass('hide', $("input[name='refund']:checked").val() == "true");
-    buildNextUrl($("input[name='refund']:checked").val() == "true" ? '#.html' : '#.html');
+    //buildNextUrl($("input[name='refund']:checked").val() == "true" ? '#.html' : '#.html');
   });

--- a/source/public/journey-7/form-number.slim
+++ b/source/public/journey-7/form-number.slim
@@ -30,5 +30,12 @@ form
   br
   .row
     .small-12.columns
-      a href='ni.html'
+      a#next-url href='ni.html'
         .button.success Continue
+
+javascript:
+  $(document).ready( function() {
+    buildNextUrl('ni.html');
+    $('#refund-true').toggle(getUrlParameter('refund') == 'true');
+    $('#refund-false').toggle(getUrlParameter('refund') == 'false');
+  });

--- a/source/public/journey-7/income-partnered.slim
+++ b/source/public/journey-7/income-partnered.slim
@@ -271,10 +271,16 @@ form
   br
   .row
     .small-12.medium-6.columns
-      a href="refund.html" 
+      a#next-url href="probate.html" 
         .button.success Continue
 
 
+javascript:
+  $(document).ready( function() {
+    buildNextUrl('savings-amount.html');
+    $('#refund-true').toggle(getUrlParameter('refund') == 'true');
+    $('#refund-false').toggle(getUrlParameter('refund') == 'false');
+  });
 javascript:
   $(document).ready( function() {
     buildNextUrl('3-savings.html');

--- a/source/public/journey-7/income-single.slim
+++ b/source/public/journey-7/income-single.slim
@@ -8,10 +8,11 @@ form
     .small-12.columns
       br
       a href="children.html" Back
-      span.hint &nbsp; &nbsp; Step 6 of 17
+      span.hint &nbsp; &nbsp; Step 9 of 18
       br
       br
-      h4 What is your total monthly income?
+      h4#refund-false What is your total monthly income?
+      h4#refund-true When you paid the fee, what was your total monthly income?
       p Enter the amount of money you get every month before any tax or National Insurance payments have been taken off.
       p If you get paid weekly, multiply your weekly pay by 52, then divide it by 12. This will give you a monthly total.
       p There are some benefits you shouldn't include as income, see the full list and further information about completing this section in the <a href="http://hmctsformfinder.justice.gov.uk/courtfinder/forms/ex160a-eng-20160212.pdf"> guide. </a>  
@@ -157,13 +158,18 @@ form
   br
   .row
     .small-12.medium-6.columns
-      a href="refund.html" 
+      a#next-url href="probate.html" 
         .button.success Continue
 
 
 javascript:
   $(document).ready( function() {
-    $('.sum-me').on('change', function() {
+    buildNextUrl('savings-amount.html');
+    $('#refund-true').toggle(getUrlParameter('refund') == 'true');
+    $('#refund-false').toggle(getUrlParameter('refund') == 'false');
+  });
+
+  $('.sum-me').on('change', function() {
       total=0;
       $('.sum-me').each(function(i,n){
         if ($(n).val() != "") {

--- a/source/public/journey-7/name.slim
+++ b/source/public/journey-7/name.slim
@@ -31,7 +31,7 @@ form
   br
   .row
     .small-12.columns
-      a href='address.html'
+      a#next-url href='address.html'
         .button.success Continue
 
 
@@ -39,9 +39,12 @@ form
 
 javascript:
   $(document).ready( function() {
+    buildNextUrl('address.html');
+    $('#refund-true').toggle(getUrlParameter('refund') == 'true');
+    $('#refund-false').toggle(getUrlParameter('refund') == 'false');
   });
 
   $("input[name='case']").on('change', function () {
     $('#case-number').toggleClass('hide', $("input[name='case']:checked").val() == "true");
-    buildNextUrl($("input[name='case']:checked").val() == "true" ? '#.html' : '#.html');
+    //buildNextUrl($("input[name='case']:checked").val() == "true" ? '#.html' : '#.html');
   });

--- a/source/public/journey-7/ni.slim
+++ b/source/public/journey-7/ni.slim
@@ -31,7 +31,7 @@ form
   br
   .row
     .small-12.columns
-      a href='dob.html'
+      a#next-url href='dob.html'
         .button.success Continue
 
 
@@ -39,9 +39,12 @@ form
 
 javascript:
   $(document).ready( function() {
+    buildNextUrl('dob.html');
+    $('#refund-true').toggle(getUrlParameter('refund') == 'true');
+    $('#refund-false').toggle(getUrlParameter('refund') == 'false');
   });
 
   $("input[name='case']").on('change', function () {
     $('#case-number').toggleClass('hide', $("input[name='case']:checked").val() == "true");
-    buildNextUrl($("input[name='case']:checked").val() == "true" ? '#.html' : '#.html');
+    // buildNextUrl($("input[name='case']:checked").val() == "true" ? '#.html' : '#.html');
   });

--- a/source/public/journey-7/partner-age.slim
+++ b/source/public/journey-7/partner-age.slim
@@ -8,7 +8,7 @@ form
     .small-12.columns
       br
       a href="savings.html" Back
-      span.hint &nbsp; &nbsp; Step 3 of 17
+      span.hint &nbsp; &nbsp; Step 5 of 18
       br
       br
       h4 Are you or your partner 61 or over?
@@ -40,7 +40,7 @@ form
   br
   .row
     .small-12.columns
-      a href='benefits.html'
+      a#next-url href='savings-amount.html'
         .button.success Continue
 
 
@@ -48,9 +48,7 @@ form
 
 javascript:
   $(document).ready( function() {
-  });
-
-  $("input[name='case']").on('change', function () {
-    $('#case-number').toggleClass('hide', $("input[name='case']:checked").val() == "false");
-    buildNextUrl($("input[name='case']:checked").val() == "true" ? '#.html' : '#.html');
+    buildNextUrl('savings-amount.html');
+    $('#refund-true').toggle(getUrlParameter('refund') == 'true');
+    $('#refund-false').toggle(getUrlParameter('refund') == 'false');
   });

--- a/source/public/journey-7/probate.slim
+++ b/source/public/journey-7/probate.slim
@@ -54,7 +54,7 @@ form
   br
   .row
     .small-12.columns
-      a href='case-number.html'
+      a#next-url href='case-number.html'
         .button.success Continue
 
 
@@ -62,9 +62,11 @@ form
 
 javascript:
   $(document).ready( function() {
+    buildNextUrl('case-number.html');
+    $('#refund-true').toggle(getUrlParameter('refund') == 'true');
+    $('#refund-false').toggle(getUrlParameter('refund') == 'false');
   });
 
   $("input[name='probate']").on('change', function () {
     $('#probate-details').toggleClass('hide', $("input[name='probate']:checked").val() == "true");
-    buildNextUrl($("input[name='probate']:checked").val() == "true" ? '#.html' : '#.html');
   });

--- a/source/public/journey-7/refund.slim
+++ b/source/public/journey-7/refund.slim
@@ -8,7 +8,7 @@ form
     .small-12.medium-9.columns
       br
       a href="benefits" Back
-      span.hint &nbsp; &nbsp; Step 7 of 17
+      span.hint &nbsp; &nbsp; Step 1 of 18
       br
       br
       h4 Have you already paid the fee?
@@ -50,7 +50,7 @@ form
   br
   .row
     .small-12.columns
-      a#next-url href='probate.html'
+      a#next-url href='status.html'
         .button.success Continue
 
 
@@ -58,8 +58,10 @@ form
 
 javascript:
   $(document).ready( function() {
+    buildNextUrl('status.html');
+    $('#refund-true').toggle(getUrlParameter('refund') == 'true');
+    $('#refund-false').toggle(getUrlParameter('refund') == 'false');
   });
-
   $("input[name='refund']").on('change', function () {
     $('#refund-details').toggleClass('hide', $("input[name='refund']:checked").val() != "true");
     $("#next-url").attr("href", updateQueryStringParameter('refund',$("input[name='refund']:checked").val() == "true"));

--- a/source/public/journey-7/refund.slim
+++ b/source/public/journey-7/refund.slim
@@ -18,11 +18,11 @@ form
       .options.radio
         .option
           label for="refund-no"
-            input id="refund-no" type="radio" name="refund" value="true"
+            input id="refund-no" type="radio" name="refund" value="false"
             | No 
             .option
           label for="refund-yes"
-            input id="refund-yes" type="radio" name="refund" value="false"
+            input id="refund-yes" type="radio" name="refund" value="true"
             | Yes
   #refund-details.hide
     .row
@@ -50,7 +50,7 @@ form
   br
   .row
     .small-12.columns
-      a href='probate.html'
+      a#next-url href='probate.html'
         .button.success Continue
 
 
@@ -61,6 +61,6 @@ javascript:
   });
 
   $("input[name='refund']").on('change', function () {
-    $('#refund-details').toggleClass('hide', $("input[name='refund']:checked").val() == "true");
-    buildNextUrl($("input[name='refund']:checked").val() == "true" ? '#.html' : '#.html');
+    $('#refund-details').toggleClass('hide', $("input[name='refund']:checked").val() != "true");
+    $("#next-url").attr("href", updateQueryStringParameter('refund',$("input[name='refund']:checked").val() == "true"));
   });

--- a/source/public/journey-7/savings-amount.slim
+++ b/source/public/journey-7/savings-amount.slim
@@ -1,0 +1,36 @@
+---
+title: 'Apply for help with fees'
+nav_title: 'GOV.UK'
+---
+
+form
+  .row
+    .small-12.columns
+      br
+      a href="savings.html" Back
+      span.hint &nbsp; &nbsp; Step 6 of 18
+      br
+      br
+      h4#refund-false How much do you have in savings and investments
+      h4#refund-true When you paid the fee, how much savings and investments did you have? 
+
+  .row
+    .small-12.medium-5.large-5.columns
+      .small-2.medium-3.large-3.columns style="padding:0px;"
+        span.prefix
+          label.inline for='fee' £
+      .small-10.medium-9.large-9.columns style="padding:0px;"
+        input id='fee' type="number"
+  br
+  .row
+    .small-12.columns
+      a#next-url href='benefits.html'
+        .button.success Continue
+
+
+javascript:
+  $(document).ready( function() {
+    buildNextUrl('benefits.html');
+    $('#refund-true').toggle(getUrlParameter('refund') == 'true');
+    $('#refund-false').toggle(getUrlParameter('refund') == 'false');
+  });

--- a/source/public/journey-7/savings.slim
+++ b/source/public/journey-7/savings.slim
@@ -8,10 +8,11 @@ form
     .small-12.medium-10.columns
       br
       a href="status.html" Back
-      span.hint &nbsp; &nbsp; Step 2 of 17
+      span.hint &nbsp; &nbsp; Step 3 of 18
       br
       br
-      h4 How much do you and your partner have in savings and investments?
+      h4#refund-false How much do you have in savings and investments?
+      h4#refund-true When you paid the fee, how much savings and investments did you have? 
   .row
     .small-12.medium-6.columns  
       .options.radio
@@ -20,8 +21,8 @@ form
             input id="payment-correct-low" type="radio" name="savings-amount" value=""
             | Less than £3,000 
         .option
-          label for="savings-amount-medium"
-            input id="savings-amount-medium" type="radio" name="savings-amount" value=""
+          label for="case-middle"
+            input id="case-middle" type="radio" name="case" value="false"
             | Between £3,000 and £16,000
         .option
           label for="savings-amount-high"
@@ -61,13 +62,14 @@ form
   br
   .row
     .small-12.medium-6.columns
-      a href='partner-age.html'
+      a#next-url href='partner-age.html'
         .button.success Continue
-
-
 
 
 javascript:
   $(document).ready( function() {
+    buildNextUrl('partner-age.html');
+    $('#refund-true').toggle(getUrlParameter('refund') == 'true');
+    $('#refund-false').toggle(getUrlParameter('refund') == 'false');
   });
 

--- a/source/public/journey-7/status.slim
+++ b/source/public/journey-7/status.slim
@@ -8,7 +8,7 @@ form
     .small-12.columns
       br
       a href="0-start.html" Back
-      span.hint &nbsp; &nbsp; Step 1 of 17
+      span.hint &nbsp; &nbsp; Step 2 of 18
       br
       br
       h4 What's your status?
@@ -49,7 +49,7 @@ form
   br
   .row
     .small-12.columns
-      a href='savings.html'
+      a#next-url href='savings.html'
         .button.success Continue
 
   br
@@ -57,3 +57,12 @@ form
     .small-12.medium-7.large-6.columns
       a#next-url href='0-start.html'
         |Back to start
+
+
+
+javascript:
+  $(document).ready( function() {
+    buildNextUrl('savings.html');
+    $('#refund-true').toggle(getUrlParameter('refund') == 'true');
+    $('#refund-false').toggle(getUrlParameter('refund') == 'false');
+  });


### PR DESCRIPTION
When applying for a refund we need to know the applicants
income/benefits _at the time they paid the fee_.

Moving the refund step to the start of the form allows us to rephrase
the income and benefit questions for this scenario.

It also allows for a better flow rather than starting with their
relationship status.
