### PR TITLE
Employment Tribunal Confirmation

### DIFF
--- a/source/public/confirmation-et.slim
+++ b/source/public/confirmation-et.slim
@@ -1,0 +1,53 @@
+---
+title: 'Apply for help with fees'
+nav_title: 'GOV.UK'
+---
+
+form
+  .row
+    .small-12.medium-9.columns
+      span.hint Step 20 of 20
+      br
+      h3 Your application for help with fees is not finished yet 
+      br
+      .row
+        .small-12.columns
+          a href="#"Save or print this page
+      br
+      p You must email or post this reference number [ HWF-xxx-xxx ] along with your Employment Tribunal case reference (Fee Group reference) to the employment tribunal that will deal with your case. 
+
+      p For people based in: 
+      ul
+        li England
+        ul
+          li Email your letter to <a href="eREMISSIONS@hmcts.gsi.gov.uk?subject=Help with fees">eREMISSIONS@hmcts.gsi.gov.uk</a> (click for preformated email) or,
+          li Post you letter to (insert address)
+        li Scotland
+        ul
+          li Email your letter to <a href="xxx@hmcts.gsi.gov.uk?subject=Help with fees">Scotland@hmcts.gsi.gov.uk</a> (click for preformated email) or,
+          li Post you letter to (insert address)
+      br
+      p You can copy the letter below to email or print this page and send it to the tribunal. 
+      br
+        .row
+          .small-12.medium-12.large-12.columns
+            .panel
+              p Reference: <strong>HWF-xxx-xxx</strong>
+              p I have completed an online application for help with fees for a refund.
+              p My employment tribunal reference is: XXXX-XXXX.
+              p Yours sincerely,
+              p Mr Mark Morgan 
+      br
+      .row
+        .small-12.medium-10.columns
+          .panel
+            h4.bold What happens next?
+            br
+            ol
+              li Your application will be assessed by court or tribunal staff. This usually takes no longer than 21 days. 
+              br
+              li You'll hear from the court or tribunal if your application is unsuccessful or if they need more information from you. 
+              br
+              li If your application is successful you'll hear directly from the court or tribunal dealing with your case.  
+  br
+  br

--- a/source/public/form-number.slim
+++ b/source/public/form-number.slim
@@ -18,6 +18,11 @@ form
       input name='form_number' id='form_number' type='text'
       .options.radio
         .option
+          label for="et-case"
+            input id="et-case" type="checkbox"
+            | This is an Employment Tribunal case
+      .options.radio
+        .option
           label for="form-unknown"
             input id="form-unknown" type="checkbox"
             | I don’t know the form name or number


### PR DESCRIPTION
Adding facility for ET applicants to add case number and a bespoke
confirmation page for ET.
