### PR TITLE
shorter intro text

### DIFF
--- a/source/public/start.slim
+++ b/source/public/start.slim
@@ -8,7 +8,7 @@ form
     .small-12.columns
       br
       h1 Apply for help with fees
-      p.large Fees depend on your savings and income, and your case or claim (see <a href="https://www.gov.uk/court-fees-what-they-are">guide to court or tribunal fees</a>). If you have no savings or a small amount, are on a low income or receive certain benefits, you may not have to pay or could get money off.
+      p.large You may not have to pay, or you may get money off, your <a href="https://www.gov.uk/court-fees-what-they-are">court and tribunal fees</a>.
   br
 
   .row


### PR DESCRIPTION
Shortened the intro text so
— it isn’t repetitive with 1st section
— includes link to court fees
— works better on mobile
